### PR TITLE
Remove package not found on pip3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ numpy==1.17.0
 oauthlib==3.1.0
 pandas>=0.24.2
 Pillow==6.1.0
-pkg-resources==0.0.0
 py-trello==0.15.0
 PyJWT==1.5.3
 PyMySQL==0.9.3


### PR DESCRIPTION
The reason being termination of pip3 installation in the middle.